### PR TITLE
wrapperClassName prop fix

### DIFF
--- a/package/src/components/DateRangePickerWrapper.tsx
+++ b/package/src/components/DateRangePickerWrapper.tsx
@@ -38,7 +38,7 @@ export interface DateRangePickerWrapperProps {
   maxDate?: Date | string;
   onChange: (dateRange: DateRange) => void;
   closeOnClickOutside?: boolean;
-  wrapperClassName: object;
+  wrapperClassName?: string;
 }
 
 const DateRangePickerWrapper: React.FunctionComponent<DateRangePickerWrapperProps> = (


### PR DESCRIPTION
wrapperClassName is in fact required, but in docs it was described as optional, fixed that. It was of `object` type, but that would not work as Wrapper component expects a `className`, replacing to `string` works.