### PR TITLE
Also export DateRangePicker without Popper and ClickAwayListener

### DIFF
--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -3,8 +3,8 @@ import DateRangePicker from './components/DateRangePicker';
 import { DateRange, DefinedRange } from './types';
 
 export {
-  DateRangePickerExporter as DateRangePickerOverlay,
-  DateRangePicker as DateRangePicker,
+  DateRangePickerExporter as DateRangePicker,
+  DateRangePicker as DateRangePickerComponent,
   DefinedRange,
   DateRange,
 };

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,8 +1,10 @@
 import DateRangePickerExporter from './components/DateRangePickerExporter';
+import DateRangePicker from './components/DateRangePicker';
 import { DateRange, DefinedRange } from './types';
 
 export {
-  DateRangePickerExporter as DateRangePicker,
+  DateRangePickerExporter as DateRangePickerOverlay,
+  DateRangePicker as DateRangePicker,
   DefinedRange,
   DateRange,
 };


### PR DESCRIPTION
This allows someone to automatically decide how the component should be shown.

@jungrafael let me know if there are any changes you want to have made.