### PR TITLE
Remove @material-ui/* dependencies and move relevant packages to peerDependencies.

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -20,6 +20,7 @@
 	},
 	"peerDependencies": {
 		"@material-ui/core": "^4.9.4",
+		"@material-ui/icons": "^4.9.1",
 		"react": "^16.8.6",
 		"react-dom": "^16.8.6"
 	},
@@ -71,8 +72,6 @@
 		"typescript": "^3.7.5"
 	},
 	"dependencies": {
-		"@material-ui/core": "^4.9.4",
-		"@material-ui/icons": "^4.9.1",
 		"classnames": "^2.2.6",
 		"date-fns": "^1.30.1"
 	},


### PR DESCRIPTION
Hi there! Thank you for this great component. It's really helped us and we're grateful for the time spent on it by you folks.

This pull request attempts to resolve the following warning in @material-ui when several instances of its packages exist in a single bundle:

![image](https://user-images.githubusercontent.com/1519443/102981408-cefdfb00-4500-11eb-9120-04c56de73ac4.png)

With `yarn list` we can see that the host project and this component library both have a dependency on `@material-ui/styles`:

![image](https://user-images.githubusercontent.com/1519443/102981684-42077180-4501-11eb-8328-bafa02b6e3c5.png)


Can we expect users of this package to already be using @materia-ui and therefore have those packages as peerDependencies? :)

Thanks for considering this change and again for creating this great component.