### PR TITLE
update react peer dependencies to support react v17

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -20,8 +20,8 @@
 	},
 	"peerDependencies": {
 		"@material-ui/core": "^4.9.4",
-		"react": "^16.8.6",
-		"react-dom": "^16.8.6"
+		"react": "^16.8.6 || ^17.0.0",
+		"react-dom": "^16.8.6 || ^17.0.0"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.0.0",
@@ -58,8 +58,8 @@
 		"eslint-plugin-jsx-a11y": "^6.2.3",
 		"eslint-plugin-react": "^7.18.3",
 		"eslint-plugin-react-hooks": "^1.7.0",
-		"react": "16.8.6",
-		"react-dom": "16.8.6",
+		"react": "16.8.6 || ^17.0.0",
+		"react-dom": "16.8.6 || ^17.0.0",
 		"react-scripts": "^3.0.1",
 		"rollup": "^1.1.2",
 		"rollup-plugin-babel": "^4.3.2",


### PR DESCRIPTION
This PR addresses https://github.com/jungsoft/materialui-daterange-picker/issues/28 and https://github.com/jungsoft/materialui-daterange-picker/issues/34 to update react peer dependencies so that we can use this package with React 17. 🎉 